### PR TITLE
Adding a readline to the script so you can see output

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"golang.org/x/sys/windows/registry"
 	"log"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 func main() {
@@ -95,5 +96,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("\nFinished.")
+	fmt.Println("\nFinished. Press Enter to close.")
+	var input string
+	fmt.Scanln(&input)
 }


### PR DESCRIPTION
Currently when running the exe file, the terminal will close before you are able to see the output. This just lets you see the output without having the run the exe from a terminal.